### PR TITLE
Update notes.md

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -27,7 +27,7 @@ msfconsole -q -x 'use exploit/multi/handler; set payload windows/meterpreter/rev
 <summary><h4>Mono Compile DLL</h4></summary>
 
 ```
-mcs -r:System.Windows.Forms.dll -target:library evil.cs
+mcs -r:System.Windows.Forms.dll -target:library evil.cs -out:evil.dll
 ```
 </details>
 
@@ -35,7 +35,7 @@ mcs -r:System.Windows.Forms.dll -target:library evil.cs
 <summary><h4>Mono Compile exe</h4></summary>
 
 ```
-mcs -platform:x64 -target:exe evil.cs
+mcs -platform:x64 -target:exe evil.cs -out:evil.exe
 ```
 </details>
 


### PR DESCRIPTION
Default cs filename in VisualStudio is Program.cs. When building binaries using mono, its handy adding the -out flag as otherwise all binaries end up called Program.exe/Program.dll